### PR TITLE
Add compiler-dom basic structure

### DIFF
--- a/packages/compiler-dom/src/htmlNesting.ts
+++ b/packages/compiler-dom/src/htmlNesting.ts
@@ -1,0 +1,9 @@
+export function isVoidTag(tag: string): boolean {
+  const voidTags = ['area','base','br','col','embed','hr','img','input','link','meta','param','source','track','wbr']
+  return voidTags.includes(tag)
+}
+
+export function isValidHTMLNesting(tag: string, parent: string): boolean {
+  if (parent === 'p' && isVoidTag(tag)) return false
+  return true
+}

--- a/packages/compiler-dom/src/index.ts
+++ b/packages/compiler-dom/src/index.ts
@@ -1,0 +1,20 @@
+import { createElementVNode } from '@vue/runtime-core'
+import { parserOptions } from './parserOptions'
+
+export function compile(template: string) {
+  template = template.trim()
+  const match = template.match(/^<(\w+)>([^]*)<\/\1>$/)
+  if (match) {
+    const [, tag, text] = match
+    return function render() {
+      return createElementVNode(tag, null, text.trim())
+    }
+  }
+  return function render() {
+    return createElementVNode('div', null, template)
+  }
+}
+
+export { parserOptions }
+export * from './runtimeHelpers'
+export * from './htmlNesting'

--- a/packages/compiler-dom/src/parserOptions.ts
+++ b/packages/compiler-dom/src/parserOptions.ts
@@ -1,0 +1,12 @@
+export interface DOMParserOptions {
+  delimiters?: [string, string]
+  isVoidTag?: (tag: string) => boolean
+}
+
+export const parserOptions: DOMParserOptions = {
+  delimiters: ['{{', '}}'],
+  isVoidTag: tag => {
+    const voidTags = ['area','base','br','col','embed','hr','img','input','link','meta','param','source','track','wbr']
+    return voidTags.includes(tag)
+  }
+}

--- a/packages/compiler-dom/src/runtimeHelpers.ts
+++ b/packages/compiler-dom/src/runtimeHelpers.ts
@@ -1,0 +1,3 @@
+export const DOMRuntimeHelpers = {
+  CREATE_ELEMENT_VNODE: 'createElementVNode'
+}

--- a/packages/compiler-dom/test/compile.test.ts
+++ b/packages/compiler-dom/test/compile.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { compile } from '../src/index'
+
+describe('compiler-dom', () => {
+  it('should return render function', () => {
+    const render = compile('<div>Hello</div>')
+    expect(typeof render).toBe('function')
+    const vnode = render()
+    expect(vnode.type).toBe('div')
+    expect(vnode.children).toBe('Hello')
+  })
+})


### PR DESCRIPTION
## Summary
- introduce `compiler-dom` package with initial source files
- add basic `compile` function using runtime-core
- include DOM parser options, runtime helpers and HTML nesting utilities
- add unit test for the compile function

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a68c2f18832ba80e52350c5e2992